### PR TITLE
switch to ocaml 4.10.2

### DIFF
--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -28,7 +28,7 @@ extra_packages="$extra_apk_packages"
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
 
-opam_switch="4.10.0+flambda"
+opam_switch="4.10.2+flambda"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -27,7 +27,7 @@ extra_packages="$extra_deb_packages"
 
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
-opam_switch="4.10.0+flambda"
+opam_switch="4.10.2+flambda"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"


### PR DESCRIPTION
We have very slow startup time with pfff and semgrep
when using ppxlib 0.20.0 in ocaml 4.10.0. This
seems to be fixed with 4.10.2 so let's update
our docker images to 4.10.2

test plan:
hoping CI flags anything