### PR TITLE
Add visitors library

### DIFF
--- a/common-config.sh
+++ b/common-config.sh
@@ -48,7 +48,7 @@ opam_packages="
   ounit2
   pcre
   parmap
-  ppxlib.0.20.0
+  ppxlib.0.22.0
   ppx_deriving
   ppx_hash
   ppx_sexp_conv
@@ -60,4 +60,5 @@ opam_packages="
   uutf
   yaml
   yojson
+  visitors.20210608
 "


### PR DESCRIPTION
I also had to bump the ppxlib version since visitors depends on v0.22.0.

I think I just run `./docker-push` and then update the reference to ocaml:alpine in the Dockerfile of the relevant repo once this is merged, right?

Test plan: `make`

### Security

- [ ] Change has security implications (if so, ping the security team)
