### PR TITLE
Add core

### DIFF
--- a/common-config.sh
+++ b/common-config.sh
@@ -28,6 +28,7 @@ opam_packages="
   atdgen
   atdpy
   bloomf
+  core
   cmdliner
   comby-kernel.1.4.1
   conf-pkg-config


### PR DESCRIPTION
### Security

Add Jane Street Core for its `Filename.realpath` functionality

Also, Core is a much more fully featured standard library.

- [ ] Change has security implications (if so, ping the security team)
