### PR TITLE
Switch to OCaml 4.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,17 @@ version: 2.1
 jobs:
   build-and-push:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:current-22.04
     steps:
       - checkout
 
       # Work around "no docker within no docker".
-      - setup_remote_docker
+      - setup_remote_docker:
+          # Note that the default version (17.09.0-ce)
+          # (see <https://circleci.com/docs/2.0/building-docker-images/#docker-version>)
+          # causes issues with permissions inside of the nested docker instances.
+          # See e.g., <https://github.com/docker-library/php/issues/1192#issuecomment-902366923>
+          version: 20.10.14
 
       - run:
           name: Build
@@ -26,12 +31,17 @@ jobs:
 
   build-only:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:current-22.04
     steps:
       - checkout
 
       # Work around "no docker within no docker".
-      - setup_remote_docker
+      - setup_remote_docker:
+          # Note that the default version (17.09.0-ce)
+          # (see <https://circleci.com/docs/2.0/building-docker-images/#docker-version>)
+          # causes issues with permissions inside of the nested docker instances.
+          # See e.g., <https://github.com/docker-library/php/issues/1192#issuecomment-902366923>
+          version: 20.10.14
 
       - run:
           name: Build

--- a/common-config.sh
+++ b/common-config.sh
@@ -48,7 +48,7 @@ opam_packages="
   ounit2
   pcre
   parmap
-  ppxlib.0.22.0
+  ppxlib
   ppx_deriving
   ppx_hash
   ppx_sexp_conv

--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -28,7 +28,7 @@ extra_packages="$extra_apk_packages"
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
 
-opam_switch="4.12.0"
+opam_switch="4.14.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -12,7 +12,7 @@ os="ubuntu"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="ubuntu:21.10"
+from="ubuntu"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/configs/ubuntu.sh
+++ b/configs/ubuntu.sh
@@ -27,7 +27,7 @@ extra_packages="$extra_deb_packages"
 
 # Opam switch to use. This determines the OCaml version and a set of
 # configuration options.
-opam_switch="4.12.0"
+opam_switch="4.14.0"
 
 # The collection of opam packages we want to install. Go wild.
 opam_packages="$opam_packages"

--- a/docker-build
+++ b/docker-build
@@ -24,7 +24,7 @@ force_tag="$date"
 from="alpine:3.12.0"
 user="user"
 extra_packages=""
-opam_switch="4.12.0"
+opam_switch="4.14.0"
 opam_switch_options=""
 opam_packages="dune utop"
 

--- a/docker-build
+++ b/docker-build
@@ -11,7 +11,7 @@
 # The list of destination docker URLs (tags) is saved to a temporary file
 # which will be consulted our 'docker-push' script.
 #
-set -eu
+set -eux
 
 # YYYY-MM-DD date, made available to all the config files, which can
 # use it for tagging the docker images.

--- a/docker-push
+++ b/docker-push
@@ -9,7 +9,7 @@
 # Usage: ./docker-push
 #
 #
-set -eu
+set -eux
 
 for docker_url in $(cat pushme); do
   echo "Pushing '$docker_url'."

--- a/src/create-dockerfile
+++ b/src/create-dockerfile
@@ -9,7 +9,7 @@ default_cmd='bash'
 default_os=alpine
 default_extra_packages=''
 default_opam_packages='dune'
-default_opam_switch='4.12.0'
+default_opam_switch='4.14.0'
 default_opam_switch_options=''
 
 usage() {

--- a/src/create-dockerfile
+++ b/src/create-dockerfile
@@ -3,7 +3,7 @@
 # Put together a Dockerfile from options specified on the command line.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu -o pipefail
+set -eux -o pipefail
 
 default_cmd='bash'
 default_os=alpine

--- a/src/opam/install-ocaml
+++ b/src/opam/install-ocaml
@@ -3,7 +3,7 @@
 # Install opam, ocaml compilers and standard library.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 mkdir -p .ssh
 chmod 700 .ssh
@@ -13,8 +13,8 @@ if [ -z "$(git config user.email)" ]; then
   git config --global user.name "Docker"
 fi
 
-opam init --disable-sandboxing
-opam switch create "$@"
+opam init --disable-sandboxing -v
+opam switch create "$@" -v
 
 cat >> ~/.bashrc <<"EOF"
 # From https://github.com/mjambon/ocaml-layer

--- a/src/opam/install-opam-packages
+++ b/src/opam/install-opam-packages
@@ -3,7 +3,7 @@
 # Install opam packages specified on the command line.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 packages=$(echo $* | sed -e 's/,/ /g')
 opam install -y $packages

--- a/src/os/alpine/create-user
+++ b/src/os/alpine/create-user
@@ -3,7 +3,7 @@
 # Create a non-privileged user on Alpine.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 error() {
   echo "Error: $*" >&2

--- a/src/os/alpine/setup
+++ b/src/os/alpine/setup
@@ -3,7 +3,7 @@
 # General system setup for Alpine Linux prior to installing Opam.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 # The command line arguments are a list of extra packages to install.
 extra_packages=$*

--- a/src/os/ubuntu/create-user
+++ b/src/os/ubuntu/create-user
@@ -3,7 +3,7 @@
 # Create a non-privileged user on a Debian-based OS.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 error() {
   echo "Error: $*" >&2

--- a/src/os/ubuntu/setup
+++ b/src/os/ubuntu/setup
@@ -3,7 +3,7 @@
 # General system setup for Ubuntu prior to installing Opam.
 # From https://github.com/mjambon/setup-ocaml
 #
-set -eu
+set -eux
 
 # The command line arguments are a list of extra packages to install.
 extra_packages=$*


### PR DESCRIPTION
Probably same notes about #5 apply as in #9, but that's more complicated.
(That being said, this isn't urgent, so maybe it would be worth taking
the time to figure it out.)

Mainly upgrading for their garbage collection improvements:
> 4.14.0
> Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20% in GC-heavy programs.

(from https://ocaml.org/releases)

Additionally, we may want to use `Unix.realpath` instead of `Common.fullpath`
if we find that the latter has limitations, but so far it's been fine

### Security

- [ ] Change has security implications (if so, ping the security team)
