### PR TITLE
Build and docker push for each master changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,17 @@ jobs:
 workflows:
   version: 2
 
-  build-on-push:
+  build-on-pr:
     jobs:
       - build-only
+
+  build-and-push-on-master-push:
+    jobs:
+      - build-and-push:
+          filters:
+            branches:
+              only:
+                - master
 
   build-and-push-weekly:
     # Rebuild periodically rather than based on git changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
-### Security
+PR checklist:
 
-- [ ] Change has security implications (if so, ping the security team)
+- [ ] PR comment includes a reproducible test plan
+- [ ] Change has no security implications (otherwise ping the security team)


### PR DESCRIPTION
This will avoid having to wait for the cron to kick in
This can also be triggered manually from circleCI dashboard

test plan:
wait for CI to kick when we merge this and see that
a docker push is triggered


### Security

- [ ] Change has security implications (if so, ping the security team)