### PR TITLE
Pin ppx_sexp_conv to avoid bug affecting v0.15.1

### DIFF
--- a/common-config.sh
+++ b/common-config.sh
@@ -67,7 +67,7 @@ opam_packages="
   ppx_deriving
   ppx_deriving_cmdliner
   ppx_hash
-  ppx_sexp_conv.0.14.3
+  ppx_sexp_conv.v0.14.3
   re
   stdcompat
   sexplib

--- a/common-config.sh
+++ b/common-config.sh
@@ -67,7 +67,7 @@ opam_packages="
   ppx_deriving
   ppx_deriving_cmdliner
   ppx_hash
-  ppx_sexp_conv
+  ppx_sexp_conv.0.14.3
   re
   stdcompat
   sexplib


### PR DESCRIPTION
The bug in question is https://github.com/janestreet/ppx_sexp_conv/issues/40

This version constraint seems not strictly needed at the moment but it aligns with the version constraint in semgrep.opam.

See also https://github.com/returntocorp/semgrep/pull/7386

test plan: CI checks

PR checklist:

- [x] PR comment includes a reproducible test plan
- [x] Change has no security implications (otherwise ping the security team)
