### PR TITLE
osemgrep now requires terminal_size

### DIFF
--- a/common-config.sh
+++ b/common-config.sh
@@ -70,6 +70,7 @@ opam_packages="
   re
   stdcompat
   sexplib
+  terminal_size
   tsort
   uri
   utop


### PR DESCRIPTION
see https://github.com/returntocorp/semgrep/pull/7530

PR checklist:

- [x] PR comment includes a reproducible test plan
- [x] Change has no security implications (otherwise ping the security team)
