### PR TITLE
publish multi-platform docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,12 @@
 version: 2.1
 
 jobs:
-  build-and-push:
-    docker:
-      - image: cimg/base:current-22.04
+  build-and-push-amd64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: medium
     steps:
       - checkout
-
-      # Work around "no docker within no docker".
-      - setup_remote_docker:
-          # Note that the default version (17.09.0-ce)
-          # (see <https://circleci.com/docs/2.0/building-docker-images/#docker-version>)
-          # causes issues with permissions inside of the nested docker instances.
-          # See e.g., <https://github.com/docker-library/php/issues/1192#issuecomment-902366923>
-          version: 20.10.14
-
       - run:
           name: Build
           command: make build
@@ -29,20 +21,38 @@ jobs:
           name: Push
           command: make push
 
-  build-only:
-    docker:
-      - image: cimg/base:current-22.04
+  build-and-push-arm64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: arm.medium
     steps:
       - checkout
+      - run:
+          name: Build
+          command: make build
+      - run:
+          name: Login
+          command: ./.circleci/docker-login
+      - run:
+          name: Push
+          command: make push
 
-      # Work around "no docker within no docker".
-      - setup_remote_docker:
-          # Note that the default version (17.09.0-ce)
-          # (see <https://circleci.com/docs/2.0/building-docker-images/#docker-version>)
-          # causes issues with permissions inside of the nested docker instances.
-          # See e.g., <https://github.com/docker-library/php/issues/1192#issuecomment-902366923>
-          version: 20.10.14
+  build-only-amd64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: make build
 
+  build-only-arm64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: arm.medium
+    steps:
+      - checkout
       - run:
           name: Build
           command: make build
@@ -52,11 +62,17 @@ workflows:
 
   build-on-pr:
     jobs:
-      - build-only
+      - build-only-amd64
+      - build-only-arm64
 
   build-and-push-on-master-push:
     jobs:
-      - build-and-push:
+      - build-and-push-amd64:
+          filters:
+            branches:
+              only:
+                - master
+      - build-and-push-arm64:
           filters:
             branches:
               only:
@@ -75,7 +91,14 @@ workflows:
                 - main
 
     jobs:
-      - build-and-push:
+      - build-and-push-amd64:
+          # Run only on these branches (each pushing different images)
+          filters:
+            branches:
+              only:
+                - master
+                - main
+      - build-and-push-arm64:
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,18 @@
 
 version: 2.1
 
+executors:
+  linux/amd64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: medium
+  linux/arm64:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: arm.medium
+
 jobs:
-  build-and-push-amd64:
+  build-and-push:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
@@ -21,36 +31,11 @@ jobs:
           name: Push
           command: make push
 
-  build-and-push-arm64:
-    machine:
-      image: ubuntu-2204:2022.07.1
-    resource_class: arm.medium
-    steps:
-      - checkout
-      - run:
-          name: Build
-          command: make build
-      - run:
-          name: Login
-          command: ./.circleci/docker-login
-      - run:
-          name: Push
-          command: make push
-
-  build-only-amd64:
-    machine:
-      image: ubuntu-2204:2022.07.1
-    resource_class: medium
-    steps:
-      - checkout
-      - run:
-          name: Build
-          command: make build
-
-  build-only-arm64:
-    machine:
-      image: ubuntu-2204:2022.07.1
-    resource_class: arm.medium
+  build-only:
+    parameters:
+      platform:
+        type: executor
+    executor: << parameters.platform >>
     steps:
       - checkout
       - run:
@@ -62,17 +47,17 @@ workflows:
 
   build-on-pr:
     jobs:
-      - build-only-amd64
-      - build-only-arm64
+      - build-only:
+          matrix:
+            parameters:
+              platform: [linux/amd64, linux/arm64]
 
   build-and-push-on-master-push:
     jobs:
-      - build-and-push-amd64:
-          filters:
-            branches:
-              only:
-                - master
-      - build-and-push-arm64:
+      - build-and-push:
+          matrix:
+            parameters:
+              platform: [linux/amd64, linux/arm64]
           filters:
             branches:
               only:
@@ -91,14 +76,10 @@ workflows:
                 - main
 
     jobs:
-      - build-and-push-amd64:
-          # Run only on these branches (each pushing different images)
-          filters:
-            branches:
-              only:
-                - master
-                - main
-      - build-and-push-arm64:
+      - build-and-push:
+          matrix:
+            parameters:
+              platform: [linux/amd64, linux/arm64]
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,21 @@
 version: 2.1
 
 executors:
-  linux/amd64:
+  amd64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
-  linux/arm64:
+  arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
 
 jobs:
   build-and-push:
-    machine:
-      image: ubuntu-2204:2022.07.1
-    resource_class: medium
+    parameters:
+      architecture:
+        type: executor
+    executor: << parameters.architecture >>
     steps:
       - checkout
       - run:
@@ -33,9 +34,9 @@ jobs:
 
   build-only:
     parameters:
-      platform:
+      architecture:
         type: executor
-    executor: << parameters.platform >>
+    executor: << parameters.architecture >>
     steps:
       - checkout
       - run:
@@ -50,14 +51,14 @@ workflows:
       - build-only:
           matrix:
             parameters:
-              platform: [linux/amd64, linux/arm64]
+              architecture: [amd64, arm64]
 
   build-and-push-on-master-push:
     jobs:
       - build-and-push:
           matrix:
             parameters:
-              platform: [linux/amd64, linux/arm64]
+              architecture: [amd64, arm64]
           filters:
             branches:
               only:
@@ -79,7 +80,7 @@ workflows:
       - build-and-push:
           matrix:
             parameters:
-              platform: [linux/amd64, linux/arm64]
+              architecture: [amd64, arm64]
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/docker-build
+++ b/docker-build
@@ -76,6 +76,7 @@ build() {
         --opam-packages "$opam_packages" \
         --opam-switch "$opam_switch" \
         --opam-switch-options "$opam_switch_options"
+
       docker build -t "$docker_url" "${extra_build_options[@]}" .
 
       # Sanity check.


### PR DESCRIPTION
This PR is a baby step towards semgrep running on `linux/arm64`:
- Migrates CircleCI jobs from the Docker to the Linux VM execution environment, which is needed for access to ARM resources
- Uses a matrix config to run platform-specific jobs (e.g. `build-and-push` --> `build-and-push-amd64`, `build-and-push-arm64`)

Notes:
- An alternative approach would be to use the docker buildx plugin to build `linux/amd64` and `linux/arm64` images in parallel. I investigated this and it was incredibly slow ([cancelled](https://app.circleci.com/pipelines/github/returntocorp/ocaml-layer/242/workflows/ae133944-d0c0-4cf7-aeff-5af4dd894149) after 2 hours)
- I looked into running this on larger machines but only saw modest improvement (e.g. build time went from 30-40 min to ~15 min, but at a 10x cost in credits (xlarge machine VM is 100 credits/min))