### PR TITLE
Disable arm64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,14 @@ workflows:
       - build-only:
           matrix:
             parameters:
-              architecture: [amd64, arm64]
+              architecture: [amd64]
 
   build-and-push-on-master-push:
     jobs:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64, arm64]
+              architecture: [amd64]
           filters:
             branches:
               only:
@@ -80,7 +80,7 @@ workflows:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64, arm64]
+              architecture: [amd64]
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,14 @@ workflows:
       - build-only:
           matrix:
             parameters:
-              architecture: [amd64]
+              architecture: [amd64, arm64]
 
   build-and-push-on-master-push:
     jobs:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64]
+              architecture: [amd64]  # TODO: re-introduce arm64 once we've figured out how to correctly publish a multi-arch docker image
           filters:
             branches:
               only:
@@ -80,7 +80,7 @@ workflows:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64]
+              architecture: [amd64]  # TODO: re-introduce arm64 once we've figured out how to correctly publish a multi-arch docker image
           # Run only on these branches (each pushing different images)
           filters:
             branches:


### PR DESCRIPTION
I've been struggling to make the build create a proper multi-arch manifest, so for now, let's just not publish arm64 images