### PR TITLE
Re-attempt multi-arch images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: make build
       - run:
           name: Tag images with arch
-          command: make tag-with-arch
+          command: make suffix-with-arch
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,23 @@ executors:
     resource_class: arm.medium
 
 jobs:
+  push-multi-arch:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Login
+          command: ./.circleci/docker-login
+      - run:
+          name: Create multi-arch images
+          command: make create-multi-arch
+      - run:
+          name: Push
+          command: make push
+
   build-and-push:
     parameters:
       architecture:
@@ -25,6 +42,13 @@ jobs:
       - run:
           name: Build
           command: make build
+      - run:
+          name: Tag images with arch
+          command: make tag-with-arch
+      - persist_to_workspace:
+          root: .
+          paths:
+            - images-*
       - run:
           name: Login
           command: ./.circleci/docker-login
@@ -58,7 +82,13 @@ workflows:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64]  # TODO: re-introduce arm64 once we've figured out how to correctly publish a multi-arch docker image
+              architecture: [amd64, arm64]
+          filters:
+            branches:
+              only:
+                - master
+      - push-multi-arch:
+          requires: [build-and-push]
           filters:
             branches:
               only:
@@ -80,7 +110,15 @@ workflows:
       - build-and-push:
           matrix:
             parameters:
-              architecture: [amd64]  # TODO: re-introduce arm64 once we've figured out how to correctly publish a multi-arch docker image
+              architecture: [amd64, arm64]
+          # Run only on these branches (each pushing different images)
+          filters:
+            branches:
+              only:
+                - master
+                - main
+      - push-multi-arch:
+          requires: [build-and-push]
           # Run only on these branches (each pushing different images)
           filters:
             branches:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ build:
 push:
 	./docker-push
 
+# Tag docker images with the current architecture. (optional: needed for multi-arch images)
+.PHONY: suffix-with-arch
+tag-with-arch:
+	./docker-suffix-with-arch
+
+# Create a multi-arch docker image from multiple arch-specific images.
+.PHONY: create-multi-arch
+push-multi-arch:
+	./docker-create-multi-arch
+
 # Build and push.
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ push:
 
 # Tag docker images with the current architecture. (optional: needed for multi-arch images)
 .PHONY: suffix-with-arch
-tag-with-arch:
+suffix-with-arch:
 	./docker-suffix-with-arch
 
 # Create a multi-arch docker image from multiple arch-specific images.
 .PHONY: create-multi-arch
-push-multi-arch:
+create-multi-arch:
 	./docker-create-multi-arch
 
 # Build and push.

--- a/docker-create-multi-arch
+++ b/docker-create-multi-arch
@@ -15,6 +15,6 @@ for image in $images; do
     for image_arch in $(cat images-* | grep ${image}$'\t' | cut -f2); do
         manifest_args+=( --amend $image_arch )
     done
-    docker manifest create $image $manifest_args
+    docker manifest create $image ${manifest_args[@]}
     echo $image >> pushme
 done

--- a/docker-create-multi-arch
+++ b/docker-create-multi-arch
@@ -12,9 +12,9 @@ images=$(cat images-* | cut -f 1 | sort | uniq)
 # create a multi-arch manifest based on the arch-specific images we find
 for image in $images; do
     manifest_args=()
-    for image_arch in $(cat images-* | grep ${image}$'\t' | cut -f2); do
-        manifest_args+=( --amend $image_arch )
+    for image_arch in $(cat images-* | grep "${image}"$'\t' | cut -f2); do
+        manifest_args+=( --amend "$image_arch" )
     done
-    docker manifest create $image ${manifest_args[@]}
-    echo $image >> pushme
+    docker manifest create "$image" "${manifest_args[@]}"
+    echo "$image" >> pushme
 done

--- a/docker-create-multi-arch
+++ b/docker-create-multi-arch
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+#
+# Create multi-arch image manifests based on arch-specific images
+#
+set -eux
+
+rm -f pushme
+
+# get set of unique images
+images=$(cat images-* | cut -f 1 | sort | uniq)
+
+# create a multi-arch manifest based on the arch-specific images we find
+for image in $images; do
+    manifest_args=()
+    for image_arch in $(cat images-* | grep ${image}$'\t' | cut -f2); do
+        manifest_args+=( --amend $image_arch )
+    done
+    docker manifest create $image $manifest_args
+    echo $image >> pushme
+done

--- a/docker-suffix-with-arch
+++ b/docker-suffix-with-arch
@@ -4,14 +4,14 @@
 #
 set -eux
 
-arch=$(docker info -f {{ .Architecture }})
+arch=$(docker info -f "{{ .Architecture }}")
 image_mapping="images-${arch}"
 rm -f $image_mapping
 
 # create a new tag suffixed with the current architecture for each image in pushme
 # write the before/after image names to a file so that we can group them for the multi-arch manifest later
 for image in $(cat pushme); do
-    $arch_image="${image}-${arch}"
+    arch_image="${image}-${arch}"
     docker tag $image $arch_image
     echo -e "${image}\t${arch_image}" >> $image_mapping
 done

--- a/docker-suffix-with-arch
+++ b/docker-suffix-with-arch
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+#
+# Disambiguates images for a multi-arch build by suffixing their tag with the current architecture.
+#
+set -eux
+
+arch=$(docker info -f {{ .Architecture }})
+image_mapping="images-${arch}"
+rm -f $image_mapping
+
+# create a new tag suffixed with the current architecture for each image in pushme
+# write the before/after image names to a file so that we can group them for the multi-arch manifest later
+for image in $(cat pushme); do
+    $arch_image="${image}-${arch}"
+    docker tag $image $arch_image
+    echo -e "${image}\t${arch_image}" >> $image_mapping
+done
+
+# update pushme to point to the new tags
+cat $image_mapping | cut -f2 > pushme

--- a/docker-suffix-with-arch
+++ b/docker-suffix-with-arch
@@ -6,15 +6,15 @@ set -eux
 
 arch=$(docker info -f "{{ .Architecture }}")
 image_mapping="images-${arch}"
-rm -f $image_mapping
+rm -f "$image_mapping"
 
 # create a new tag suffixed with the current architecture for each image in pushme
 # write the before/after image names to a file so that we can group them for the multi-arch manifest later
 for image in $(cat pushme); do
     arch_image="${image}-${arch}"
-    docker tag $image $arch_image
-    echo -e "${image}\t${arch_image}" >> $image_mapping
+    docker tag "$image" "$arch_image"
+    echo -e "${image}\t${arch_image}" >> "$image_mapping"
 done
 
 # update pushme to point to the new tags
-cat $image_mapping | cut -f2 > pushme
+cat "$image_mapping" | cut -f2 > pushme


### PR DESCRIPTION
I was mistaken when I thought that https://github.com/returntocorp/ocaml-layer/pull/24 was all we needed for multi-arch builds. In reality, we need to push arch-specific images to Docker Hub and then create a new manifest that unites the arch-specific images. (e.g. `returntocorp/ocaml:alpine` = `returntocorp/ocaml:alpine-aarch64` + `returntocorp/ocaml:alpine-x86_64`).

In this PR:
1. Bring back the arm64 builds
2. Suffix each arch-specific image's tag with the current architecture so that we can disambiguate when pushing to Docker Hub (tag was being overwritten in PR 24) and creating the multi-arch manifest
2. Push these suffixed images to Docker Hub
3. After the arch-specific images have been built and pushed, build an push a new manifest for each image that points to the arch-specific manifests

test plan:
manually test pieces with different image / name
