### PR TITLE
fix: docker manifest push instead of docker push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,8 @@ jobs:
           name: Login
           command: ./.circleci/docker-login
       - run:
-          name: Create multi-arch images
-          command: make create-multi-arch
-      - run:
-          name: Push
-          command: make push
+          name: Create and push a multi-arch image manifest
+          command: make push-multi-arch
 
   build-and-push:
     parameters:

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ push:
 suffix-with-arch:
 	./docker-suffix-with-arch
 
-# Create a multi-arch docker image from multiple arch-specific images.
-.PHONY: create-multi-arch
-create-multi-arch:
-	./docker-create-multi-arch
+# Create and push a multi-arch docker image from multiple arch-specific images
+.PHONY: push-multi-arch
+push-multi-arch:
+	./docker-push-multi-arch
 
 # Build and push.
 .PHONY: all

--- a/docker-push-multi-arch
+++ b/docker-push-multi-arch
@@ -18,3 +18,9 @@ for image in $images; do
     docker manifest create "$image" "${manifest_args[@]}"
     echo "$image" >> pushme
 done
+
+# push multi-arch manifests
+for image in $images; do
+  echo "Pushing image manifest '$image'."
+  docker manifest push "$image"
+done


### PR DESCRIPTION
https://github.com/returntocorp/ocaml-layer/pull/27 got us **almost** there... Arch-specific images are being pushed, but the final multi-arch manifest push failed because we were running `docker push` when we should have been doing `docker manifest push`. When I tested PR 27 locally I must have run `docker manifest push` and then mistakenly assumed that the `docker-push` command would work too.

I just manually tested this end-to-end and confirmed that things look good (ex. [returntocorp/ocaml:alpine-2023-05-01](https://hub.docker.com/layers/returntocorp/ocaml/alpine-2023-05-01/images/sha256-f98dd0429753cd6e5670a01ae71064d4adbc7734086ffa2ea993e761674935a7?context=explore) has images for both architectures)