### PR TITLE
Use lwt_ssl over tls-lwt for https

### DIFF
--- a/common-config.sh
+++ b/common-config.sh
@@ -38,7 +38,7 @@ opam_packages="
   bloomf
   bos
   cmdliner
-  cohttp-lwt-unix
+  'cohttp-lwt-unix>=5.3.0'
   conf-pkg-config
   conf-autoconf
   ctypes_stubs_js
@@ -52,8 +52,6 @@ opam_packages="
   fmt
   fpath
   grain_dypgen
-  'happy-eyeballs>=0.6.0'
-  http-lwt-client
   integers_stubs_js
   junit_alcotest
   js_of_ocaml
@@ -63,6 +61,7 @@ opam_packages="
   lsp.1.15.1-5.0
   lwt
   lwt_ppx
+  'lwt_ssl>=1.2.0'
   merlin
   menhir.20220210
   num
@@ -86,7 +85,6 @@ opam_packages="
   sexplib
   terminal_size
   timedesc
-  tls-lwt
   tsort
   uri
   utop

--- a/common-config.sh
+++ b/common-config.sh
@@ -14,6 +14,7 @@ extra_apk_packages="
   npm
   openssl
   pcre-dev
+  pkg-config
   python3
 "
 
@@ -23,6 +24,7 @@ extra_deb_packages="
   cargo
   libgmp-dev
   libpcre3-dev
+  libssl-dev
   nodejs
   npm
   pkg-config

--- a/common-config.sh
+++ b/common-config.sh
@@ -12,6 +12,7 @@ extra_apk_packages="
   gmp-dev
   nodejs
   npm
+  openssl
   pcre-dev
   python3
 "


### PR DESCRIPTION
## Description
Remove `tls-lwt` lib and replaces  with`lwt_ssl`. Also removes unused happy eyeballs / old lwt client.

- [ ] PR comment includes a reproducible test plan
- [ ] Change has no security implications (otherwise ping the security team)
