### PR TITLE
fix: update opam in installation

### DIFF
--- a/src/opam/install-ocaml
+++ b/src/opam/install-ocaml
@@ -16,6 +16,9 @@ fi
 opam init --disable-sandboxing -v
 opam switch create "$@" -v
 
+# update opam to have the latest packages before installing
+opam update
+
 cat >> ~/.bashrc <<"EOF"
 # From https://github.com/mjambon/ocaml-layer
 echo 'Running "eval $(opam env)", which initializes PATH and other variables.'


### PR DESCRIPTION
## What:
This PR makes it so that in the OCaml installation phase, we update our `opam` with the latest packages.

## Why:
Right now, we have a CI issue in upgrading to OCaml 5.0 because we are failing to install the most recent version of `semver`. This is because we use the `ocaml-layer` built Docker image, which never updates its `opam` with the most recent packages.

## How:
Inserted an `opam update`, which will ensure that users of this Docker image have all the latest `opam` packages.

## Test plan:
Tried out the built Docker image locally and verified it had `semver` 0.2.1, which the previous Docker image did not.

PR checklist:

- [X] PR comment includes a reproducible test plan
- [X] Change has no security implications (otherwise ping the security team)
