### PR TITLE
Switch to alpine 3.18.4

### DIFF
--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -12,7 +12,7 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+from="alpine:3.18.4"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/configs/alpine5.sh
+++ b/configs/alpine5.sh
@@ -12,7 +12,7 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+from="alpine:3.18.4"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.


### PR DESCRIPTION
I had troubles installing eio_linux in opam because
it requires a more recent kernel with SYS_clone3 that
is not available in alpine 3.12.0

I was also not available to install gh under our current
docker image and I hope this might solve the issue too

test plan:
wait for green CI check


PR checklist:

- [ ] PR comment includes a reproducible test plan
- [ ] Change has no security implications (otherwise ping the security team)