### PR TITLE
upgrade alpine

### DIFF
--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -12,7 +12,7 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+from="alpine:3.18.0"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/configs/alpine5.sh
+++ b/configs/alpine5.sh
@@ -12,7 +12,7 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+from="alpine:3.18.0"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.


### PR DESCRIPTION
alpine 12 has been out of support for almost 18 months, upgrade to the current stable.

PR checklist:

- [ ] PR comment includes a reproducible test plan
- [ ] Change has no security implications (otherwise ping the security team)
