### PR TITLE
upgrade alpine to 3.15

### DIFF
--- a/configs/alpine.sh
+++ b/configs/alpine.sh
@@ -12,7 +12,8 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+# Only pin to minor version, not patch to ensure rebuilds pull in security fixes
+from="alpine:3.15"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/configs/alpine5.sh
+++ b/configs/alpine5.sh
@@ -12,7 +12,8 @@ os="alpine"
 
 # The argument of the FROM line in the dockerfile. This is the docker
 # URL of the base image, optionally followed by more things.
-from="alpine:3.12.0"
+# Only pin to minor version, not patch to ensure rebuilds pull in security fixes
+from="alpine:3.15"
 
 # This is the argument of 'docker pull', 'docker push', etc. for the image
 # we are building.

--- a/src/opam/install-ocaml
+++ b/src/opam/install-ocaml
@@ -20,7 +20,7 @@ opam switch create "$@" -v
 opam update
 
 cat >> ~/.bashrc <<"EOF"
-# From https://github.com/mjambon/ocaml-layer
+# From https://github.com/semgrep/ocaml-layer
 echo 'Running "eval $(opam env)", which initializes PATH and other variables.'
 echo
 echo 'In scripts and dockerfiles, don't forget to run your commands as


### PR DESCRIPTION
3.12 went out of support middle of last year
3.15 works, but ran out of support a week ago
3.16+ fails because of depext issues

I suspect opam changing from 2.0.8 -> 2.1 between these releases of alpine.
I created a follow up for that: https://linear.app/semgrep/issue/PA-3244/upgrade-ocaml-build-environment-to-a-supported-version-of-alpine

Tested building locally, will wait for CI to do it's thing.

PR checklist:

- [X] PR comment includes a reproducible test plan
- [X] Change has no security implications (otherwise ping the security team)
